### PR TITLE
feat: add CDN node filter by colo (allow/block list)

### DIFF
--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -53,6 +53,12 @@ type Config struct {
 
 	// DiversityWeight controls how much diversity affects arm selection (0-1).
 	DiversityWeight float64
+
+	// ColoAllow is a whitelist of CDN colo codes; only results with colo in this list enter TopN. Empty = no filter.
+	ColoAllow []string
+
+	// ColoBlock is a blacklist of CDN colo codes; results with colo in this list do not enter TopN. Empty = no filter.
+	ColoBlock []string
 }
 
 // Request holds the input for a search run.
@@ -121,6 +127,9 @@ func (c *Config) Validate() error {
 	}
 	if c.DiversityWeight < 0 || c.DiversityWeight > 1 {
 		return fmt.Errorf("diversityWeight must be in [0,1], got %f", c.DiversityWeight)
+	}
+	if len(c.ColoAllow) > 0 && len(c.ColoBlock) > 0 {
+		return fmt.Errorf("cannot use both colo allow and colo exclude; use only one")
 	}
 	return nil
 }

--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,21 @@ go run ./cmd/mcis -v --out text --cidr-file ./ipv6cidr.txt
 - `--seed`：随机种子（0 表示使用时间种子）
 - `-v`：输出进度到 stderr
 
+### 按 colo 过滤 CDN 节点
+
+探测请求的响应（如 `/cdn-cgi/trace`）中若包含 `colo` 字段，表示该 IP 对应的 CDN 机房代码（如 Cloudflare 的 `HKG`、`SJC` 等）。可通过以下参数只保留或排除指定机房的节点进入最终 Top N 结果：
+
+- `--colo`：**白名单**，逗号分隔的 colo 列表；仅这些机房的节点会进入结果。例如：`--colo HKG,SJC`
+- `--colo-exclude`：**黑名单**，逗号分隔的 colo 列表；这些机房的节点不会进入结果。例如：`--colo-exclude LAX,DFW`
+
+未设置时不过滤，所有探测成功的节点按延迟参与排名。`--colo` 与 `--colo-exclude` 只能二选一，不能同时使用。
+
+示例（只保留香港和圣何塞节点）：
+
+```bash
+./mcis -v --out text --cidr-file ./ipv4cidr.txt --colo HKG,SJC
+```
+
 ### 下载速度测试参数（对前几名 IP 测速）
 
 搜索结束后，可对排名靠前的 IP 进行**下载速度测试**（默认 URL：`https://speed.cloudflare.com/__down?bytes=50000000`）。


### PR DESCRIPTION
- Add ColoAllow/ColoBlock to engine config with validation
- Filter in processOneResult before topN.Consider; tree.Update unchanged
- CLI: --colo (whitelist), --colo-exclude (blacklist), comma-separated
- Docs: readme section for colo filtering with examples

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds optional result-filtering based on the `trace` `colo` field and simple CLI/config validation, without changing probing/scheduling behavior beyond which results are eligible for TopN.
> 
> **Overview**
> Adds an optional **CDN colo filter** that controls which probe results are eligible to enter the final TopN ranking based on the response `trace` `colo` field.
> 
> Extends `engine.Config` with `ColoAllow`/`ColoBlock` plus validation to prevent using both, wires new CLI flags `--colo` and `--colo-exclude` (comma-separated) into config, and applies the filter in `Engine.processOneResult` before `topN.Consider` (while still updating the bandit tree). Documentation is updated with usage and examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfe9d24df2e9117f01b1f3562d1444e33f0d8da1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->