### PR TITLE
feat: 添加 --host 参数域名格式验证

### DIFF
--- a/cmd/mcis/main.go
+++ b/cmd/mcis/main.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"regexp"
 	"sort"
 	"strings"
 	"syscall"
@@ -26,6 +27,42 @@ func (r *repeatStringFlag) String() string { return strings.Join(*r, ",") }
 func (r *repeatStringFlag) Set(v string) error {
 	*r = append(*r, v)
 	return nil
+}
+
+// isValidDomain validates if a string is a valid domain name.
+// Returns true if the domain is valid, false otherwise.
+func isValidDomain(domain string) bool {
+	if domain == "" {
+		return false
+	}
+
+	// Maximum length check (253 characters)
+	if len(domain) > 253 {
+		return false
+	}
+
+	// Domain regex pattern:
+	// - Each label: alphanumeric + hyphens, but not starting/ending with hyphen
+	// - Labels separated by dots
+	// - Must have at least one dot (to distinguish from plain hostnames)
+	// - Total length up to 253 characters
+	// - Each label up to 63 characters
+	const domainPattern = `^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$`
+
+	re := regexp.MustCompile(domainPattern)
+	if !re.MatchString(domain) {
+		return false
+	}
+
+	// Check each label length (max 63 chars per label)
+	labels := strings.Split(domain, ".")
+	for _, label := range labels {
+		if len(label) > 63 {
+			return false
+		}
+	}
+
+	return true
 }
 
 func main() {
@@ -124,6 +161,12 @@ func main() {
 	flag.StringVar(&coloExclude, "colo-exclude", "", "Comma-separated colo blacklist; exclude these CDN nodes from results (e.g. LAX,DFW)")
 
 	flag.Parse()
+
+	// Validate --host parameter
+	if !isValidDomain(host) {
+		fmt.Fprintf(os.Stderr, "error: --host must be a valid domain name, got: %s\n", host)
+		os.Exit(1)
+	}
 
 	// Colo: at most one of allow vs exclude
 	if coloAllow != "" && coloExclude != "" {


### PR DESCRIPTION
## 功能描述

为 --host 参数添加域名格式验证，确保用户输入的是有效的域名。

## 变更内容

- 在 cmd/mcis/main.go 中添加 isValidDomain() 函数
- 在 flag.Parse() 后添加验证逻辑，无效域名时程序输出错误并退出

## 验证规则

- ✅ 必须包含至少一个点（区别于纯主机名）
- ✅ 每个标签 1-63 字符，总长不超过 253 字符
- ✅ 只允许字母、数字和连字符
- ✅ 标签不能以连字符开头或结尾