### PR TITLE
feat: add --download-mode parameter with sequential mode

### DIFF
--- a/cmd/mcis/main.go
+++ b/cmd/mcis/main.go
@@ -83,6 +83,7 @@ func main() {
 		dlBytes   int64
 		dlTimeout time.Duration
 		dlURL     string
+		dlMode    string
 		outFmt    string
 		outPath   string
 		splitV4   int
@@ -130,6 +131,7 @@ func main() {
 	flag.Int64Var(&dlBytes, "download-bytes", 0, "Download test size in bytes; 0 = 50M for default endpoint, no limit for custom URL (default: 0)")
 	flag.DurationVar(&dlTimeout, "download-timeout", 45*time.Second, "Per-IP download test timeout")
 	flag.StringVar(&dlURL, "download-url", "", "Custom download test URL (e.g. https://myhost.com/path/to/file). Overrides default speed.cloudflare.com")
+	flag.StringVar(&dlMode, "download-mode", "all", "Download test mode: 'all' (test top N) or 'sequential' (test sequentially until N successes)")
 	flag.StringVar(&outFmt, "out", "jsonl", "Output format: jsonl|csv|text")
 	flag.StringVar(&outPath, "out-file", "", "Write output to file (default: stdout)")
 	flag.IntVar(&splitV4, "split-step-v4", 2, "When splitting an IPv4 prefix, increase prefix bits by this step")
@@ -292,7 +294,16 @@ func main() {
 					dlTop, dlBytes)
 			}
 		}
-		for i := 0; i < dlTop; i++ {
+		// Download test with mode support
+		var testCount, successCount int
+		var maxTests int
+		if dlMode == "sequential" {
+			maxTests = len(res.Top) // Sequential mode: test until we have enough successes or run out of IPs
+		} else {
+			maxTests = dlTop // All mode: test exactly dlTop IPs
+		}
+
+		for i := 0; i < maxTests && successCount < dlTop; i++ {
 			r := &res.Top[i]
 			dctx, dcancel := context.WithTimeout(ctx, dlTimeout)
 			dr := dlp.Download(dctx, r.IP)
@@ -302,10 +313,22 @@ func main() {
 			r.DownloadMS = dr.TotalMS
 			r.DownloadMbps = dr.Mbps
 			r.DownloadError = dr.Error
+			testCount++
+			if dr.OK {
+				successCount++
+			}
 			if verbose {
 				fmt.Fprintf(os.Stderr, "download: rank=%d ip=%s ok=%v mbps=%.2f ms=%d bytes=%d err=%s\n",
 					i+1, r.IP.String(), dr.OK, dr.Mbps, dr.TotalMS, dr.Bytes, dr.Error)
 			}
+			// In sequential mode, stop when we have enough successes
+			if dlMode == "sequential" && successCount >= dlTop {
+				break
+			}
+		}
+		if verbose && dlMode == "sequential" {
+			fmt.Fprintf(os.Stderr, "download: mode=sequential tested=%d succeeded=%d target=%d\n",
+				testCount, successCount, dlTop)
 		}
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,7 @@ go run ./cmd/mcis -v --out text --cidr-file ./ipv6cidr.txt --budget 4000 --heads
 | `--download-bytes` | 50000000 | 下载大小（字节）；使用 `--download-url` 时不传则默认不限制 |
 | `--download-timeout` | 45s | 单 IP 测速超时 |
 | `--download-url` | （空） | 自定义测速文件地址（见下方说明） |
+| `--download-mode` | `all` | 测速模式：`all`（测速前 N 个）或 `sequential`（顺序测速直到成功 N 个） |
 
 **自定义测速地址：** 由于 Cloudflare 默认测速端点 `speed.cloudflare.com/__down` 对生成的下载文件大小可能存在限制，可通过 `--download-url` 指定自定义的测速文件地址。
 
@@ -169,6 +170,19 @@ go run ./cmd/mcis -v --out text --cidr-file ./ipv6cidr.txt --budget 4000 --heads
 **注意：** 不限制大小时单次下载可能很大，请视情况调大 `--download-timeout`；流量约等于「文件大小 × 参与测速的 IP 数」。
 
 **可用的测速大文件地址：** 可使用自己部署在 Cloudflare 后的静态大文件；或使用走 Cloudflare CDN 的公开下载链接（如厂商官网的安装包、镜像等）。社区整理的可选地址可参考 [CloudflareSpeedTest 讨论区](https://github.com/XIU2/CloudflareSpeedTest/discussions/490)。
+
+**测速模式说明：**
+
+- `all`（默认）：测速前 `--download-top` 个 IP，不管是否成功
+- `sequential`：按排名顺序逐个测速，**直到成功数达到 `--download-top` 时立即停止**，可节省时间
+
+```bash
+# 默认模式：测速前 5 个 IP（可能有些会失败）
+./mcis -v --out text --cidr-file ./ipv4cidr.txt --download-top 5 --download-mode all
+
+# 顺序模式：按顺序测速，直到 5 个成功就停（如果前 5 个都成功，就只测 5 个）
+./mcis -v --out text --cidr-file ./ipv4cidr.txt --download-top 5 --download-mode sequential
+```
 
 ### DNS 自动上传
 


### PR DESCRIPTION
## Summary

添加 `--download-mode` 参数，支持两种下载测速模式：

- **`all`** (默认): 测试前 N 个 IP，无论成功或失败
- **`sequential`**: 按顺序测试 IP，直到成功数达到目标值时停止

## Motivation

在某些网络环境下，部分 IP 可能无法通过下载测速（连接失败、超时等）。使用 `sequential` 模式可以：

1. **节省时间**: 无需等待所有 IP 测试完成，达到目标成功数即可停止
2. **提高效率**: 自动跳过失败的 IP，专注于获取足够数量的有效结果
3. **灵活控制**: 用户可以精确控制需要多少个成功的测速结果

## Usage

```bash
# 新模式：按顺序测速，成功 5 个就停止
./mcis -v --out text --cidr-file ./ipv4cidr.txt --download-top 5 --download-mode sequential

# 原模式（默认）：测试前 5 个 IP
./mcis -v --out text --cidr-file ./ipv4cidr.txt --download-top 5 --download-mode all
```

## Changes

- `cmd/mcis/main.go`: 添加 `--download-mode` 参数，实现 `sequential` 模式逻辑
- `readme.md`: 更新参数文档和使用示例

## Testing

- [x] 代码编译通过
- [x] `all` 模式保持原有行为
- [x] `sequential` 模式按预期工作（成功数达标后停止）