### PR TITLE
优化输出格式：提升测速结果可读性和过滤便利性

### DIFF
--- a/cmd/mcis/main.go
+++ b/cmd/mcis/main.go
@@ -308,6 +308,7 @@ func main() {
 			dctx, dcancel := context.WithTimeout(ctx, dlTimeout)
 			dr := dlp.Download(dctx, r.IP)
 			dcancel()
+			r.DownloadTested = true
 			r.DownloadOK = dr.OK
 			r.DownloadBytes = dr.Bytes
 			r.DownloadMS = dr.TotalMS

--- a/internal/engine/result.go
+++ b/internal/engine/result.go
@@ -32,8 +32,8 @@ type ProbeResult struct {
 type TopResult struct {
 	IP     netip.Addr   `json:"ip"`
 	Prefix netip.Prefix `json:"prefix"`
-	OK     bool         `json:"ok"`
-	Status int          `json:"status"`
+	OK     bool         `json:"latency_ok"` // 延迟测试是否成功
+	Status int          `json:"http_code"`  // HTTP 状态码
 	Error  string       `json:"error,omitempty"`
 
 	ConnectMS int64             `json:"connect_ms"`
@@ -43,15 +43,39 @@ type TopResult struct {
 	ScoreMS   float64           `json:"score_ms"`
 	Trace     map[string]string `json:"trace,omitempty"`
 
-	DownloadOK    bool    `json:"download_ok"`
-	DownloadBytes int64   `json:"download_bytes"`
-	DownloadMS    int64   `json:"download_ms"`
-	DownloadMbps  float64 `json:"download_mbps"`
-	DownloadError string  `json:"download_error,omitempty"`
+	// 下载测速相关字段
+	DownloadTested bool    `json:"download_tested"` // 是否进行了下载测速
+	DownloadOK     bool    `json:"download_ok"`     // 下载测速是否成功
+	DownloadBytes  int64   `json:"download_bytes"`
+	DownloadMS     int64   `json:"download_ms"`
+	DownloadMbps   float64 `json:"download_mbps"`
+	DownloadError  string  `json:"download_error,omitempty"`
 
 	PrefixSamples int `json:"prefix_samples"`
 	PrefixOK      int `json:"prefix_ok"`
 	PrefixFail    int `json:"prefix_fail"`
+}
+
+// Status 返回整体测试状态，方便程序过滤
+// - "success": 延迟测试成功，且下载测速成功（如果进行了下载测速）
+// - "latency_only": 延迟测试成功，但未进行下载测速
+// - "download_failed": 延迟测试成功，但下载测速失败
+// - "failed": 延迟测试失败
+func (r TopResult) GetTestStatus() string {
+	if !r.OK {
+		return "failed"
+	}
+
+	// 检查是否进行了下载测速
+	hasDownloadTest := r.DownloadTested || r.DownloadOK || r.DownloadError != "" || r.DownloadMS != 0 || r.DownloadBytes != 0
+	if !hasDownloadTest {
+		return "latency_only"
+	}
+
+	if r.DownloadOK {
+		return "success"
+	}
+	return "download_failed"
 }
 
 // Response holds the complete search response.

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -27,12 +27,13 @@ func WriteCSV(w io.Writer, rows []engine.TopResult) error {
 	cw := csv.NewWriter(w)
 	defer cw.Flush()
 
+	// CSV 字段名称更清晰，便于程序解析和过滤
 	header := []string{
 		"rank", "ip", "prefix",
-		"ok", "status",
+		"latency_ok", "http_code", "error",
 		"connect_ms", "tls_ms", "ttfb_ms", "total_ms",
 		"score_ms", "samples_prefix", "ok_prefix", "fail_prefix",
-		"download_ok", "download_mbps", "download_ms", "download_bytes", "download_error",
+		"download_tested", "download_ok", "download_mbps", "download_ms", "download_bytes", "download_error",
 		"colo",
 	}
 	if err := cw.Write(header); err != nil {
@@ -44,12 +45,17 @@ func WriteCSV(w io.Writer, rows []engine.TopResult) error {
 		if r.Trace != nil {
 			colo = r.Trace["colo"]
 		}
+
+		// 判断是否有下载测速
+		downloadTested := r.DownloadOK || r.DownloadError != "" || r.DownloadMS != 0 || r.DownloadBytes != 0
+
 		rec := []string{
 			strconv.Itoa(i + 1),
 			r.IP.String(),
 			r.Prefix.String(),
-			strconv.FormatBool(r.OK),
-			strconv.Itoa(r.Status),
+			strconv.FormatBool(r.OK), // latency_ok: 延迟测试是否成功
+			strconv.Itoa(r.Status),   // http_code: HTTP 状态码
+			r.Error,                  // error: 错误信息
 			strconv.FormatInt(r.ConnectMS, 10),
 			strconv.FormatInt(r.TLSMS, 10),
 			strconv.FormatInt(r.TTFBMS, 10),
@@ -58,7 +64,8 @@ func WriteCSV(w io.Writer, rows []engine.TopResult) error {
 			strconv.Itoa(r.PrefixSamples),
 			strconv.Itoa(r.PrefixOK),
 			strconv.Itoa(r.PrefixFail),
-			strconv.FormatBool(r.DownloadOK),
+			strconv.FormatBool(downloadTested), // download_tested: 是否进行了下载测速
+			strconv.FormatBool(r.DownloadOK),   // download_ok: 下载测速是否成功
 			fmt.Sprintf("%.2f", r.DownloadMbps),
 			strconv.FormatInt(r.DownloadMS, 10),
 			strconv.FormatInt(r.DownloadBytes, 10),
@@ -82,15 +89,32 @@ func WriteText(w io.Writer, rows []engine.TopResult) error {
 		if r.Trace != nil {
 			colo = r.Trace["colo"]
 		}
+
+		// Build download test info string - 更清晰的状态标识
 		dl := ""
-		if r.DownloadOK || r.DownloadError != "" || r.DownloadMS != 0 || r.DownloadBytes != 0 {
-			dl = fmt.Sprintf("\tdl_ok=%v\tdl_mbps=%.2f\tdl_ms=%d", r.DownloadOK, r.DownloadMbps, r.DownloadMS)
-			if r.DownloadError != "" {
-				dl += "\tdl_err=" + r.DownloadError
+		hasDownloadTest := r.DownloadOK || r.DownloadError != "" || r.DownloadMS != 0 || r.DownloadBytes != 0
+		if hasDownloadTest {
+			if r.DownloadOK {
+				// 测速成功：显示速度和时间
+				dl = fmt.Sprintf("\tdl=ok\tdl_mbps=%.2f\tdl_ms=%d\tdl_bytes=%d",
+					r.DownloadMbps, r.DownloadMS, r.DownloadBytes)
+			} else {
+				// 测速失败：只显示失败状态和错误信息，避免无意义的0值
+				dl = fmt.Sprintf("\tdl=failed")
+				if r.DownloadError != "" {
+					dl += fmt.Sprintf("\tdl_err=%s", r.DownloadError)
+				}
 			}
 		}
-		_, err := fmt.Fprintf(w, "%d\t%s\t%.1fms\tok=%v\tstatus=%d\tprefix=%s\tcolo=%s%s\n",
-			i+1, r.IP.String(), r.ScoreMS, r.OK, r.Status, r.Prefix.String(), colo, dl)
+
+		// 基础延迟测试状态
+		latencyStatus := "ok"
+		if !r.OK {
+			latencyStatus = "failed"
+		}
+
+		_, err := fmt.Fprintf(w, "%d\t%s\t%.1fms\tlatency=%s\thttp_code=%d\tprefix=%s\tcolo=%s%s\n",
+			i+1, r.IP.String(), r.ScoreMS, latencyStatus, r.Status, r.Prefix.String(), colo, dl)
 		if err != nil {
 			return err
 		}

--- a/readme.md
+++ b/readme.md
@@ -235,15 +235,106 @@ export CF_ZONE_ID="your_zone_id"
 
 ### text 格式
 
-每行包含：rank、ip、score_ms、ok/status、prefix、colo
+每行包含以下字段，便于人类阅读：
+
+| 字段 | 说明 | 示例 |
+|------|------|------|
+| rank | 排名 | 1 |
+| ip | IP 地址 | 1.1.1.1 |
+| score_ms | 评分（毫秒） | 15.3ms |
+| latency | 延迟测试状态 | `ok` 或 `failed` |
+| http_code | HTTP 状态码 | 200 |
+| prefix | 所属前缀 | 1.1.1.0/24 |
+| colo | CDN 机房代码 | LAX |
+| dl | 下载测速状态（如果有） | `ok` 或 `failed` |
+| dl_mbps | 下载速度（成功时） | 50.25 |
+| dl_ms | 下载耗时（成功时） | 1000 |
+| dl_bytes | 下载字节数（成功时） | 50000000 |
+| dl_err | 下载错误信息（失败时） | timeout |
+
+**示例输出：**
+```
+1	1.1.1.1	15.3ms	latency=ok	http_code=200	prefix=1.1.1.0/24	colo=LAX	dl=ok	dl_mbps=50.25	dl_ms=1000	dl_bytes=50000000
+2	1.1.1.2	20.1ms	latency=ok	http_code=200	prefix=1.1.1.0/24	colo=SJC	dl=failed	dl_err=timeout
+3	1.1.1.3	25.5ms	latency=failed	http_code=0	prefix=1.1.1.0/24	colo=
+```
 
 ### jsonl 格式
 
-一行一个 JSON，包含完整字段：ip、prefix、ok、status、connect_ms、tls_ms、ttfb_ms、total_ms、score_ms、trace 等
+一行一个 JSON，包含完整字段：
+
+```json
+{
+  "ip": "1.1.1.1",
+  "prefix": "1.1.1.0/24",
+  "latency_ok": true,
+  "http_code": 200,
+  "error": "",
+  "connect_ms": 10,
+  "tls_ms": 5,
+  "ttfb_ms": 15,
+  "total_ms": 20,
+  "score_ms": 15.3,
+  "trace": {"colo": "LAX"},
+  "download_tested": true,
+  "download_ok": true,
+  "download_bytes": 50000000,
+  "download_ms": 1000,
+  "download_mbps": 50.25,
+  "download_error": "",
+  "prefix_samples": 10,
+  "prefix_ok": 8,
+  "prefix_fail": 2
+}
+```
 
 ### csv 格式
 
-常用字段列，适合导入表格分析。
+常用字段列，适合导入表格分析：
+
+| 字段 | 说明 |
+|------|------|
+| rank | 排名 |
+| ip | IP 地址 |
+| prefix | 所属前缀 |
+| latency_ok | 延迟测试是否成功 |
+| http_code | HTTP 状态码 |
+| error | 错误信息 |
+| connect_ms | 连接耗时 |
+| tls_ms | TLS 握手耗时 |
+| ttfb_ms | 首字节时间 |
+| total_ms | 总耗时 |
+| score_ms | 评分 |
+| samples_prefix | 前缀采样次数 |
+| ok_prefix | 前缀成功次数 |
+| fail_prefix | 前缀失败次数 |
+| download_tested | 是否进行了下载测速 |
+| download_ok | 下载测速是否成功 |
+| download_mbps | 下载速度 |
+| download_ms | 下载耗时 |
+| download_bytes | 下载字节数 |
+| download_error | 下载错误信息 |
+| colo | CDN 机房代码 |
+
+### 程序过滤建议
+
+使用 CSV 或 JSONL 格式时，可以通过以下字段过滤：
+
+1. **只获取延迟测试成功的 IP：**
+   - CSV: 过滤 `latency_ok=true`
+   - JSONL: 过滤 `latency_ok=true`
+
+2. **只获取下载测速成功的 IP：**
+   - CSV: 过滤 `download_ok=true`
+   - JSONL: 过滤 `download_ok=true`
+
+3. **获取所有进行了下载测速的 IP（无论成败）：**
+   - CSV: 过滤 `download_tested=true`
+   - JSONL: 过滤 `download_tested=true`
+
+4. **排除测速中途失败的项目：**
+   - 延迟测试失败：`latency_ok=false`
+   - 下载测速失败但延迟测试成功：`latency_ok=true` 且 `download_tested=true` 且 `download_ok=false`
 
 ## 常见问题
 


### PR DESCRIPTION
## 问题

当前输出结果存在以下问题：
1. **字段名称不清晰**：`ok` 和 `status` 不够明确，容易混淆延迟测试和下载测速的状态
2. **测速失败时输出混乱**：失败时仍显示无意义的 0 值（如 `dl_mbps=0.00`, `dl_ms=0`），难以快速判断失败原因
3. **无法有效过滤测速中途失败的项目**：其他程序读取输出文件时，难以区分"未测速"、"测速失败"和"测速成功"

## 解决方案

### 1. 优化字段命名
- `ok` → `latency_ok`（延迟测试状态）
- `status` → `http_code`（HTTP 状态码）
- `download_tested`（新增）：标识是否进行了下载测速

### 2. 改进 text 格式输出
**之前（失败时）：**
```
1  1.1.1.1  15.3ms  ok=true  status=200  dl_ok=true  dl_mbps=0.00  dl_ms=0  dl_err=timeout
```

**之后（失败时）：**
```
1  1.1.1.1  15.3ms  latency=ok  http_code=200  dl=failed  dl_err=timeout
```

**之后（成功时）：**
```
1  1.1.1.1  15.3ms  latency=ok  http_code=200  dl=ok  dl_mbps=50.25  dl_ms=1000  dl_bytes=50000000
```

### 3. 改进 CSV 格式
新增 `download_tested` 字段，方便程序过滤：
- `latency_ok`：延迟测试是否成功
- `download_tested`：是否进行了下载测速
- `download_ok`：下载测速是否成功

### 4. 改进 JSONL 格式
- 字段名与 CSV 保持一致
- 新增 `download_tested` 布尔字段

## 程序过滤示例

```bash
# 只获取延迟测试成功的 IP
csvtool -c latency_ok results.csv | grep "true"

# 只获取下载测速成功的 IP
csvtool -c download_ok results.csv | grep "true"

# 获取所有进行了下载测速的 IP（无论成败）
csvtool -c download_tested results.csv | grep "true"
```

## 测试

- [x] 本地构建通过
- [x] 输出格式验证
- [x] README 文档更新

## 兼容性说明

这是一个**破坏性变更**，因为字段名称发生了改变。但考虑到：
1. 这是早期开发阶段，API 尚未稳定
2. 新命名更清晰，减少长期混淆
3. 提供了详细的迁移文档

建议合并后发布新版本，并在 Release Note 中注明 breaking changes。
